### PR TITLE
Fix the display width when mixes cjk and english string.

### DIFF
--- a/tabwriter.go
+++ b/tabwriter.go
@@ -14,9 +14,8 @@ package tabwriter
 import (
 	"bytes"
 	"io"
-	"unicode/utf8"
 
-	"golang.org/x/text/width"
+	"github.com/mattn/go-runewidth"
 )
 
 // ----------------------------------------------------------------------------
@@ -385,39 +384,9 @@ func (b *Writer) append(text []byte) {
 	b.cell.size += len(text)
 }
 
-func kindWidth(k width.Kind) int {
-	switch k {
-	case width.EastAsianAmbiguous:
-		return 1
-	case width.EastAsianWide:
-		return 2
-	case width.EastAsianFullwidth:
-		return 2
-	}
-	return 1
-}
-
-// calculate display width
-// CJK word covers 2 columes
-func (b *Writer) displayWidth(words []byte) (dw int) {
-	for i := 0; i < len(words); {
-		p, s := width.Lookup(words)
-		if s <= 0 {
-			return
-		}
-		dw += kindWidth(p.Kind())
-		i += s
-	}
-	return
-}
-
 // Update the cell width.
 func (b *Writer) updateWidth() {
-	displayWidth := b.displayWidth(b.buf.Bytes()[b.pos:b.buf.Len()])
-	if displayWidth == 0 {
-		displayWidth = utf8.RuneCount(b.buf.Bytes()[b.pos:b.buf.Len()])
-
-	}
+	displayWidth := runewidth.StringWidth(string(b.buf.Bytes()[b.pos:b.buf.Len()]))
 	b.cell.width += displayWidth
 	b.pos = b.buf.Len()
 }

--- a/tabwriter_test.go
+++ b/tabwriter_test.go
@@ -376,8 +376,8 @@ var tests = []struct {
 			"aaa\tèèèè\t\n",
 
 		"       a       è       c\n" +
-			"      aa     èèè    cccc   ddddd\n" +
-			"     aaa    èèèè\n",
+			"      aa   èèè    cccc   ddddd\n" +
+			"     aaa èèèè\n",
 	},
 
 	{
@@ -606,6 +606,26 @@ var tests = []struct {
 			"a\n" +
 			"a\t|b\t|c\t|d\n" +
 			"a\t|b\t|c\t|d\t|e\n",
+	},
+
+	{
+		"17a",
+		1, 0, 4, '.', 0,
+		"一二三abc\tb\tc\n" +
+			"hello\tb\tc",
+
+		"一二三abc....b....c\n" +
+			"hello........b....c",
+	},
+
+	{
+		"17b",
+		1, 0, 4, '.', 0,
+		"123abc\tb\tc\n" +
+			"hello\tb\tc",
+
+		"123abc....b....c\n" +
+			"hello.....b....c",
 	},
 }
 


### PR DESCRIPTION
Hi!
Thank you for your nice library😆!

I want to use text mixed cjk with english, but disps below output.

```
hello你好   this      is        a         test      from      wei
你好hello      hello     世界      world     。        再见      ：）
```

cjk words should be disped with 2 word width(font width).
So I fix like the below. This is computing the displayWidth with mattn/go-runewidth library.

```
hello你好   this      is        a         test      from      wei
你好hello   hello     世界      world     。        再见      ：）
```

Thanks!
